### PR TITLE
fix: target TYPO3 v14.3 LTS instead of ^14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     with:
         php-versions: '["8.2","8.3","8.4","8.5"]'
-        typo3-versions: '["^12.4","^13.4","^14.0"]'
+        typo3-versions: '["^12.4","^13.4","^14.3"]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "require": {
         "php": "^8.2",
         "nikic/php-parser": "^4.15 || ^5.0",
-        "typo3/cms-core": "^12.4 || ^13.4 || ^14.0",
-        "typo3/cms-install": "^12.4 || ^13.4 || ^14.0"
+        "typo3/cms-core": "^12.4 || ^13.4 || ^14.3",
+        "typo3/cms-install": "^12.4 || ^13.4 || ^14.3"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",


### PR DESCRIPTION
## Problem

`^14.0` also matches the unsupported v14.0 / 14.1 / 14.2 sprint
releases, not just the v14 LTS line.

## Fix

Pin to `^14.3` (TYPO3 v14.3 LTS, released 2026-04-21) in `composer.json`
(`typo3/cms-core`, `typo3/cms-install`) and the CI matrix.
