### PR TITLE
fix(docs): move <extension> out of <project> in guides.xml

### DIFF
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -4,9 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.phpdoc.org/guides https://www.phpdoc.org/guides.xsd"
 >
-    <project title="Extension Scanner CLI" release="1.0.0" copyright="since 2025 by Netresearch DTT GmbH">
-        <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" />
-    </project>
+    <project title="Extension Scanner CLI" release="1.0.0" copyright="since 2025 by Netresearch DTT GmbH" />
+    <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" />
     <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
     <inventory id="t3start" url="https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/"/>
 </guides>


### PR DESCRIPTION
## Problem
`ci / docs / Render Documentation` fails on `main`:
```
Fatal error: InvalidConfigurationException: Unrecognized option "extension"
under "guides.project". Available options are "copyright", "release",
"title", "version".
```
The fleet-wide docs-render step (render-guides 0.39.1, pinned) treats an `<extension>` nested inside `<project>…</project>` as an unknown `project` option.

## Fix
Make `<project>` self-closing and place `<extension>` as its sibling — the structure the working sibling repos use.

## Verification
Rendered locally against the exact pinned image (`render-guides@sha256:6080cbe…`): 5 documents rendered, exit 0.