### PR TITLE
feat(rector): enable rector with the shared org config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,8 @@ jobs:
     with:
       php-versions: '["8.2","8.3","8.4","8.5"]'
       typo3-versions: '["^12.4","^13.4","^14.3"]'
+      # netresearch/typo3-ci-workflows is unresolvable under typo3/cms-core ^12.4
+      # (saschaegerer/phpstan-typo3 ^2||^3 requires cms-core >= 13.4).
+      remove-dev-deps: '[{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.3"}]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+$configure = require_once __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
+
+return static function (RectorConfig $rectorConfig) use ($configure): void {
+    // Shared org base config: paths, code-quality sets, rule skips, importNames,
+    // phpVersion and the package's ergebnis-free phpstan-rector.neon.
+    $configure($rectorConfig, __DIR__ . '/..');
+
+    // paths() REPLACES the shared list, so the standard entries are repeated
+    // here to add Tests/ to the scanned tree.
+    $rectorConfig->paths([
+        __DIR__ . '/../Classes',
+        __DIR__ . '/../Configuration',
+        __DIR__ . '/../Resources',
+        __DIR__ . '/../Tests',
+    ]);
+};

--- a/Classes/Command/ExtensionScannerCommand.php
+++ b/Classes/Command/ExtensionScannerCommand.php
@@ -158,7 +158,7 @@ class ExtensionScannerCommand extends Command
             return Command::FAILURE;
         }
 
-        if (empty($pathsToScan)) {
+        if ($pathsToScan === []) {
             $io->warning('No extensions found to scan');
 
             return Command::SUCCESS;
@@ -196,6 +196,7 @@ class ExtensionScannerCommand extends Command
         if ($totalStrong > 0) {
             return Command::FAILURE;
         }
+
         if ($failOnWeak && $totalWeak > 0) {
             return 2; // Custom exit code for weak-only matches
         }
@@ -225,6 +226,7 @@ class ExtensionScannerCommand extends Command
 
                 return null;
             }
+
             $pathsToScan['custom'] = rtrim($customPath, '/');
         } elseif ($scanAll) {
             foreach ($this->packageManager->getActivePackages() as $package) {
@@ -232,15 +234,17 @@ class ExtensionScannerCommand extends Command
                 if (!$includeSystem && $package->getValueFromComposerManifest('type') === 'typo3-cms-framework') {
                     continue;
                 }
+
                 $pathsToScan[$package->getPackageKey()] = $package->getPackagePath();
             }
-        } elseif (!empty($extensions)) {
+        } elseif ($extensions !== []) {
             foreach ($extensions as $extensionKey) {
                 if (!$this->packageManager->isPackageActive($extensionKey)) {
                     $io->error(\sprintf('Extension not found or not active: %s', $extensionKey));
 
                     return null;
                 }
+
                 $package = $this->packageManager->getPackage($extensionKey);
                 $pathsToScan[$extensionKey] = $package->getPackagePath();
             }

--- a/Classes/Dto/ScanMatch.php
+++ b/Classes/Dto/ScanMatch.php
@@ -101,7 +101,7 @@ final readonly class ScanMatch
             indicator: isset($rawMatch['indicator']) && \is_string($rawMatch['indicator']) ? $rawMatch['indicator'] : 'strong',
             message: isset($rawMatch['message']) && \is_string($rawMatch['message']) ? $rawMatch['message'] : 'Unknown issue',
             matcherClass: $matcherClass,
-            restFiles: \is_array($restFiles) ? array_values(array_filter($restFiles, '\is_string')) : [],
+            restFiles: \is_array($restFiles) ? array_values(array_filter($restFiles, \is_string(...))) : [],
         );
     }
 

--- a/Classes/Output/CheckstyleOutputFormatter.php
+++ b/Classes/Output/CheckstyleOutputFormatter.php
@@ -50,6 +50,7 @@ class CheckstyleOutputFormatter implements OutputFormatterInterface
                 if (!isset($matchesByFile[$absolutePath])) {
                     $matchesByFile[$absolutePath] = [];
                 }
+
                 $matchesByFile[$absolutePath][] = $match;
             }
         }

--- a/Classes/Service/ExtensionScannerService.php
+++ b/Classes/Service/ExtensionScannerService.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Netresearch\ExtensionScannerCli\Service;
 
 use Netresearch\ExtensionScannerCli\Dto\ScanMatch;
+use PhpParser\Error;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
@@ -159,14 +160,14 @@ class ExtensionScannerService
         ?callable $parseErrorCallback = null,
     ): array {
         $matches = [];
-        $parser = $parser ?? $this->getParser();
-        $matcherConfigurations = $matcherConfigurations ?? $this->getMatcherConfigurations();
+        $parser ??= $this->getParser();
+        $matcherConfigurations ??= $this->getMatcherConfigurations();
 
         $fileContent = $file->getContents();
 
         try {
             $statements = $parser->parse($fileContent);
-        } catch (\PhpParser\Error $e) {
+        } catch (Error $e) {
             if ($parseErrorCallback !== null) {
                 $parseErrorCallback($file->getRelativePathname(), $e->getMessage());
             }
@@ -297,7 +298,7 @@ class ExtensionScannerService
      */
     private function getParser(): Parser
     {
-        if ($this->parser === null) {
+        if (!$this->parser instanceof Parser) {
             $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
         }
 

--- a/Tests/Unit/Dto/ScanMatchTest.php
+++ b/Tests/Unit/Dto/ScanMatchTest.php
@@ -8,6 +8,8 @@ use Netresearch\ExtensionScannerCli\Dto\ScanMatch;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Install\ExtensionScanner\Php\Matcher\MethodCallMatcher;
+use TYPO3\CMS\Install\ExtensionScanner\Php\Matcher\MethodCallStaticMatcher;
 
 #[CoversClass(ScanMatch::class)]
 final class ScanMatchTest extends TestCase
@@ -61,7 +63,7 @@ final class ScanMatchTest extends TestCase
             1,
             'strong',
             'msg',
-            'TYPO3\\CMS\\Install\\ExtensionScanner\\Php\\Matcher\\MethodCallMatcher',
+            MethodCallMatcher::class,
         );
 
         self::assertSame('MethodCallMatcher', $match->getMatcherName());
@@ -84,7 +86,7 @@ final class ScanMatchTest extends TestCase
             1,
             'strong',
             'msg',
-            'TYPO3\\CMS\\Install\\ExtensionScanner\\Php\\Matcher\\MethodCallStaticMatcher',
+            MethodCallStaticMatcher::class,
         );
 
         self::assertSame('Method Call Static', $match->getMatchType());

--- a/Tests/Unit/Output/JsonOutputFormatterTest.php
+++ b/Tests/Unit/Output/JsonOutputFormatterTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
+use TYPO3\CMS\Install\ExtensionScanner\Php\Matcher\MethodCallMatcher;
 
 #[CoversClass(JsonOutputFormatter::class)]
 final class JsonOutputFormatterTest extends TestCase
@@ -84,7 +85,7 @@ final class JsonOutputFormatterTest extends TestCase
                     42,
                     'strong',
                     'Deprecated API usage',
-                    'TYPO3\\CMS\\Install\\ExtensionScanner\\Php\\Matcher\\MethodCallMatcher',
+                    MethodCallMatcher::class,
                     ['Deprecation-12345.rst'],
                 ),
             ],

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "require-dev": {
         "phpstan/phpstan": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.0",
+        "netresearch/typo3-ci-workflows": "^1.3",
         "typo3/testing-framework": "^8.0 || ^9.0"
     },
     "autoload": {
@@ -55,7 +56,11 @@
         "sort-packages": true,
         "allow-plugins": {
             "typo3/cms-composer-installers": true,
-            "typo3/class-alias-loader": true
+            "typo3/class-alias-loader": true,
+            "a9f/fractor-extension-installer": true,
+            "infection/extension-installer": true,
+            "captainhook/hook-installer": true,
+            "phpstan/extension-installer": false
         },
         "audit": {
             "ignore": [
@@ -75,7 +80,9 @@
             "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
         ],
         "ci:cgl": "php-cs-fixer fix --config=.php-cs-fixer.dist.php",
+        "ci:rector": "rector process --config Build/rector.php",
         "ci:test:php:cgl": "php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff",
+        "ci:test:php:rector": "rector process --config Build/rector.php --dry-run",
         "ci:test:php:phpstan": "phpstan analyse -c Build/phpstan/phpstan.neon --error-format=github",
         "ci:test:php:unit": "phpunit -c phpunit.xml --testsuite \"Unit Tests\"",
         "ci:test:php:functional": "phpunit -c phpunit.xml --testsuite \"Functional Tests\""


### PR DESCRIPTION
This repo had no Rector configuration at all, so it was the only kind of gap the shared baseline cannot cover: nothing to judge the code against. It now delegates to the shared Rector base config from [netresearch/typo3-ci-workflows v1.3.4](https://github.com/netresearch/typo3-ci-workflows/releases/tag/v1.3.4), which is the same move as [t3x-nr-image-optimize#150](https://github.com/netresearch/t3x-nr-image-optimize/pull/150) and the rest of that campaign — with the difference that here the config is new rather than converted. Keeping the rule baseline in one package is also what made the Rector 2.6.0 breakage (the removed `SetList::STRICT_BOOLEANS` constant) fixable centrally instead of in every consumer.

The new `Build/rector.php` is deliberately thin: the shared config owns the sets, the rule skips, `importNames()`, `phpVersion()` and the Rector-only PHPStan neon. The one local override is `paths()`, which has to repeat the standard entries because `paths()` replaces rather than merges, and adds `Tests/` so the test code is covered too. No TYPO3 level set is configured yet — deciding between `UP_TO_TYPO3_13` and `UP_TO_TYPO3_14` for an extension that supports `^12.4` through `^14.3` is a separate question, tracked as [typo3-ci-workflows#155](https://github.com/netresearch/typo3-ci-workflows/issues/155).

`composer.json` gains the `ci:rector` and `ci:test:php:rector` scripts that the reusable CI workflow auto-detects (so no `rector-command` input is needed), plus the `allow-plugins` entries the meta-package pulls in transitively. `phpstan/extension-installer` is set to `false` on purpose: enabling it would auto-register `saschaegerer/phpstan-typo3`, the strict rules and the ergebnis rules at level 10 in one step, which is its own migration and not part of adopting Rector. Setting it explicitly to `false` keeps PHPStan behaving exactly as before and avoids an interactive prompt. The local `phpstan`, `php-cs-fixer` and `typo3/testing-framework` pins stay for the same reason as in contexts_wurfl: the `^12.4` cells run without the meta-package and still need those tools.

`.github/workflows/ci.yml` gains the `remove-dev-deps` guard in the same commit as the `require-dev` entry, because the meta-package is unresolvable under `typo3/cms-core ^12.4` (`saschaegerer/phpstan-typo3 ^2||^3` requires `cms-core >= 13.4`) and this repo runs a `^12.4` matrix cell. I verified both directions locally rather than assuming: with the dev dep present under `^12.4` Composer fails on `netresearch/typo3-ci-workflows ^1.3 -> satisfiable by [v1.3.0, ..., v1.3.4]`, and with it removed the same constraint set resolves to 128 packages. The Rector job itself is not TYPO3-matrixed and installs the highest version, so it keeps the shared config.

The first Rector run changed six files — mostly `empty()` to `=== []`, `?? =` shorthand, string class names to `::class`, an FQCN moved into a `use`, and blank lines from the coding-style set. One change needed a manual correction and is worth flagging: `FunctionFirstClassCallableRector` rewrote the string callable `'\is_string'` into `\\is_string(...)`, a double namespace separator that does not parse, so the very next Rector run died with a syntax error on that file. The intended result, `\is_string(...)`, is written out by hand rather than skipping the rule, and Rector leaves it alone afterwards. This looks like a genuine Rector defect for string callables that already carry a leading backslash.

Verification ran against a CI-matched cold install (`platform.php 8.2.33` — the first entry of `php-versions`, which is the PHP the Rector job uses; pin removed again before committing, and `composer.lock` is gitignored), resolving `typo3-ci-workflows v1.3.4` and `rector/rector 2.6.1`. Rector and PHP-CS-Fixer each reach a fixpoint against the other across alternating rounds with the Rector cache cleared, PHPStan at level 10 reports no errors, and all 24 unit tests pass. The two mandatory regression greps from the nr-llm findings (literal closure return types, deleted inline `@var` above a `return`) come back empty, as does the `protected` to `private` check — this extension has no Extbase domain models, no scheduler tasks and no traits, so the `PRIVATIZATION` set had nothing to reach.
