### PR TITLE
chore(deps): allow the composer-normalize plugin

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -111,7 +111,7 @@ jobs:
     permissions: {}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "phpstan/phpstan": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "netresearch/typo3-ci-workflows": "^1.3",
+        "netresearch/typo3-ci-workflows": "^1.4",
         "typo3/testing-framework": "^8.0 || ^9.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "bin-dir": ".Build/bin",
         "sort-packages": true,
         "allow-plugins": {
+            "ergebnis/composer-normalize": true,
             "typo3/cms-composer-installers": true,
             "typo3/class-alias-loader": true,
             "a9f/fractor-extension-installer": true,


### PR DESCRIPTION
This PR adds `ergebnis/composer-normalize` to `config.allow-plugins` — a Composer plugin that is not allowed gets installed but never runs — and raises the `netresearch/typo3-ci-workflows` constraint from `^1.3` to `^1.4`, because v1.4.0 is the first release of the shared package that ships that plugin at all.

## Correction to earlier revisions of this description

Two things earlier revisions of this description said were wrong, and I am withdrawing both.

**The old constraint was never broken.** A caret takes the highest matching release, so `^1.3` means `>=1.3.0 <2.0.0` and, with no committed `composer.lock` in this repo, already resolves to v1.4.0 with the plugin present. Earlier text here leaned on a `--prefer-lowest` run that locked v1.3.0 without `composer-normalize` and presented it as proof that the `allow-plugins` entry did nothing. That is only what `--prefer-lowest` does; neither this repo's `.github/workflows/ci.yml` nor the shared reusable workflow it calls passes that flag anywhere, so it never described a resolution anyone would actually get. Measured just now with a minimal probe project holding nothing but the previous constraint, against an empty `COMPOSER_CACHE_DIR`:

```
composer.json: {"require-dev": {"netresearch/typo3-ci-workflows": "^1.3"}}

$ composer update --dry-run
Lock file operations: 194 installs, 0 updates, 0 removals
  - Locking ergebnis/composer-normalize (2.52.0)
  - Locking netresearch/typo3-ci-workflows (v1.4.0)
```

The same holds in this repo: on `origin/main`, with the pre-PR `^1.3`, `composer update --dry-run` locks `netresearch/typo3-ci-workflows (v1.4.0)` and `ergebnis/composer-normalize (2.52.0)`.

**A build error quoted here came from a different repository.** The block previously read `sh: 1: .Build/bin/phpstan: not found`. This repo never emitted that string. Its own failure is quoted correctly below.

The `^1.4` constraint itself stays. Its justification is a declaration fix: the `allow-plugins` entry this PR adds names a package that only v1.4.0 supplies, so `composer.json` should require the version its own config depends on rather than leave it to whichever release the resolver happens to pick. It is not a fix for a resolution that ever failed.

## The resolution does not change

Before (`origin/main`, `^1.3`) and after (this branch, `^1.4`), `composer update --dry-run` locks the same set — same packages, same versions:

```
Lock file operations: 195 installs, 0 updates, 0 removals
```

195 is Composer's own count of distinct locked packages, and `- Locking` lines counted individually agree (195 in each run; a naive `grep -c '^  - '` returns 390 because every package appears once as `- Locking` and again as `- Installing`). A `diff` of the two sorted name-and-version lists is empty. The bump constrains which resolutions are *permitted*, not the one Composer picks today.

## Why the dedup was dropped from this PR

This PR originally also removed the dev dependencies `netresearch/typo3-ci-workflows` provides. That is wrong for this repo, and CI said so: [run 30986879327](https://github.com/netresearch/t3x-nr-extension-scanner-cli/actions/runs/30986879327) failed 8 jobs, every one of them on a `^12.4` matrix leg — PHPStan and Unit Tests across PHP 8.2 through 8.5. From [`PHPStan (8.2, ^12.4)`](https://github.com/netresearch/t3x-nr-extension-scanner-cli/actions/runs/30986879327/job/92243761329):

```
sh: 1: phpstan: not found
Script phpstan analyse -c Build/phpstan/phpstan.neon --error-format=github handling the ci:test:php:phpstan event returned with error code 127
##[error]Process completed with exit code 127.
```

and from [`Unit Tests (8.2, ^12.4)`](https://github.com/netresearch/t3x-nr-extension-scanner-cli/actions/runs/30986879327/job/92243761304):

```
sh: 1: phpunit: not found
Script phpunit -c phpunit.xml --testsuite "Unit Tests" handling the ci:test:php:unit event returned with error code 127
```

`.github/workflows/ci.yml` carries

```yaml
remove-dev-deps: '[{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.3"}]'
```

so on the **TYPO3 12.4 legs the shared package is removed entirely** — it is unresolvable there, since `saschaegerer/phpstan-typo3` requires `cms-core >= 13.4`. On those legs the local declarations are the only source of phpstan, php-cs-fixer, the testing framework and PHPUnit. They are not duplicates; they are load-bearing, and they stay.

## Key placement in allow-plugins

The key was left where this PR put it. That block is not in alphabetical order to begin with (`typo3/*` precedes `a9f/*`, `infection/*` precedes `captainhook/*`), so there is no alphabetical position to restore it to.
