### PR TITLE
feat(rector): add the TYPO3 v13 level set

### DIFF
--- a/Build/rector.php
+++ b/Build/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 
 $configure = require_once __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
 
@@ -18,5 +19,11 @@ return static function (RectorConfig $rectorConfig) use ($configure): void {
         __DIR__ . '/../Configuration',
         __DIR__ . '/../Resources',
         __DIR__ . '/../Tests',
+    ]);
+
+    // TYPO3 migration level: v13, the lowest still-supported major
+    // (typo3-ci-workflows#155); raise when v13 support is dropped.
+    $rectorConfig->sets([
+        Typo3LevelSetList::UP_TO_TYPO3_13,
     ]);
 };


### PR DESCRIPTION
Adds `Typo3LevelSetList::UP_TO_TYPO3_13` per the fleet convention recorded on [typo3-ci-workflows#155](https://github.com/netresearch/typo3-ci-workflows/issues/155). Rector is already at its fixpoint under the new set (zero code changes; gate: CGL after style fix, rector dry-run, PHPStan all green locally).